### PR TITLE
Fix V3FarAutoByYuvi compile errors and adopt shared hardware classes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,12 @@ Guidance for Claude Code when working in this repository. This is an **FTC (FIRS
 
 | Package | Contents |
 |---|---|
-| (root) | Alliance/start selectors & stores (`AllianceStore`, `AllianceMirror`, `AutoStartStore`, `AllianceSelectorTeleOp`, `CloseFarSelectorTeleOp`) |
+| (root) | Alliance/start selectors & stores (`AllianceStore`, `AllianceMirror`, `AutoStartStore`, `AllianceSelectorTeleOp`, `CloseFarSelectorTeleOp`); `RobotConfig` (central device-name constants) |
 | `hardwareClasses/` | Subsystem/hardware wrapper classes (see glossary) |
 | `autos/` | Autonomous opmodes (`V3Auto`, `V3FarAuto`, `V3ClosePartner`) |
 | `teles/` | Primary teleop (`V3Tele`) |
 | `tuners/` | Gain/feedforward tuning opmodes (`FeedForwardTuner`, `FlywheelKpTuner`, `ManualControl`) |
-| `modernTests/` | Bring-up/test opmodes (`FlywheelASGTest`) |
+| `modernTests/` | Bring-up/test opmodes (`FlywheelTest`) |
 | `pedroPathing/` | Pedro Pathing `Constants` and `Tuning` |
 
 The codebase was swept clean of prior-season and superseded files (old V2 teleops, legacy autos, OpenCV/older vision pipelines, duplicate subsystem classes, dead tuners/tests). A full snapshot of everything removed is preserved at git tag `season-2025-decode-archive` if old code is ever needed for reference. Nothing in the current tree is off-limits "scratch" — any file may be live. If you're unsure whether something is current, ask rather than assuming.
@@ -29,8 +29,8 @@ The codebase was swept clean of prior-season and superseded files (old V2 teleop
 - Name opmodes **descriptively** in the `@TeleOp(name=...)` / `@Autonomous(name=...)` string. Don't worry about Driver Station ordering prefixes (the `"A "` prefixes in existing names are just a manual sort hack) — Jason manages ordering.
 
 **Hardware classes (`hardwareClasses/`)**
-- For **new** hardware classes, use **constructor injection**: take `HardwareMap` (and any deps like `VoltageSensor`) in the constructor so the object is ready to use after construction — follow `FlywheelASG`, not `Turret`'s separate `init()` method.
-- **Device names are string literals** (e.g. `"shootTop"`/`"shootBottom"`, `"intake_motor"`, `"hoodServo"`, `"armServo"`/`"clutchServo"`) passed to `hardwareMap.get(...)`. There is **no central config file** — reuse the exact names already used in existing opmodes (grep `V3Tele`/`V3Auto`). **Never invent a new device name**; if you need one that doesn't exist yet, ask.
+- For **new** hardware classes, use **constructor injection**: take `HardwareMap` (and any deps like `VoltageSensor`) in the constructor so the object is ready to use after construction — every hardware class (`Flywheel`, `Turret`, `Hood`, `Feeder`, `Intake`) now follows this pattern.
+- **Device names live in `RobotConfig`** (root `teamcode/` package) as `public static final String` constants — reference these (e.g. `RobotConfig.FLYWHEEL_TOP`, `RobotConfig.INTAKE_MOTOR`, `RobotConfig.HOOD_SERVO`) instead of inlining string literals. The string **values** must match the Control Hub robot configuration exactly, so don't change a value without re-configuring the hub. **Never invent a new device name**; if you need one that doesn't exist yet, ask.
 - **Naming new hardware classes**: use plain, simple subsystem names (`Hood`, `Feeder`, `Intake`) — don't append suffixes like `ASG` unless asked. If the name would collide with an existing class, ask Jason how he wants to disambiguate rather than picking a suffix yourself.
 
 **Units & control gains (enforce these)**
@@ -50,7 +50,7 @@ The codebase was swept clean of prior-season and superseded files (old V2 teleop
 
 > The robot shoots game "artifacts" into a goal: an intake feeds a flywheel shooter aimed by a turret + adjustable hood. This list will go stale as new mechanisms/classes are added — update it when that happens.
 
-- **`FlywheelASG`** — shooter flywheel(s); velocity-controlled (rad/s, kP + kV/kS feedforward, bang-bang spin-up). `shootTop`/`shootBottom` motors.
+- **`Flywheel`** — shooter flywheel(s); velocity-controlled (rad/s, kP + kV/kS feedforward, bang-bang spin-up). `flywheelTop`/`flywheelBottom` motors (config names `shootTop`/`shootBottom`).
 - **`Turret`** — rotates the shooter to aim at the goal (degrees, ±180).
 - **`Hood`** — adjustable hood angle (launch angle) via servo; maps hood angle → servo position (`hoodServo`).
 - **`Intake`** — intake motor that pulls in artifacts (`intake_motor`).

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotConfig.java
@@ -1,0 +1,39 @@
+package org.firstinspires.ftc.teamcode;
+
+/**
+ * Central registry of hardware device names. Every string here must match the
+ * device name in the Control Hub robot configuration exactly.
+ *
+ * Reference these constants instead of inlining string literals so a hardware
+ * rename is a one-file change and the compiler catches typos.
+ */
+public final class RobotConfig {
+
+    private RobotConfig() {}
+
+    // Shooter flywheels (velocity-controlled, rad/s)
+    public static final String FLYWHEEL_TOP = "shootTop";
+    public static final String FLYWHEEL_BOTTOM = "shootBottom";
+
+    // Turret aim motor
+    public static final String TURRET_MOTOR = "turretMotor";
+
+    // Intake
+    public static final String INTAKE_MOTOR = "intake_motor";
+
+    // Hood (launch-angle servo)
+    public static final String HOOD_SERVO = "hoodServo";
+
+    // Feeder (arm + clutch servos)
+    public static final String FEEDER_ARM_SERVO = "armServo";
+    public static final String FEEDER_CLUTCH_SERVO = "clutchServo";
+
+    // Drivetrain
+    public static final String DRIVE_LEFT_FRONT = "leftFront";
+    public static final String DRIVE_LEFT_BACK = "leftBack";
+    public static final String DRIVE_RIGHT_FRONT = "rightFront";
+    public static final String DRIVE_RIGHT_BACK = "rightBack";
+
+    // Localizer
+    public static final String PINPOINT = "pinpoint";
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autos/V3Auto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autos/V3Auto.java
@@ -1,5 +1,7 @@
 package org.firstinspires.ftc.teamcode.autos;
 
+import org.firstinspires.ftc.teamcode.RobotConfig;
+
 import com.pedropathing.follower.Follower;
 import com.pedropathing.geometry.BezierCurve;
 import com.pedropathing.geometry.BezierLine;
@@ -14,7 +16,7 @@ import com.qualcomm.robotcore.util.Range;
 
 import org.firstinspires.ftc.teamcode.AutoStartStore;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Feeder;
-import org.firstinspires.ftc.teamcode.hardwareClasses.FlywheelASG;
+import org.firstinspires.ftc.teamcode.hardwareClasses.Flywheel;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Hood;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Intake;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Turret;
@@ -31,7 +33,7 @@ public class V3Auto extends LinearOpMode {
     private Follower follower;
     private Turret turret;
     private Intake intake;
-    private FlywheelASG flywheel;
+    private Flywheel flywheel;
 
     private boolean isRedAlliance = false;
 
@@ -170,15 +172,14 @@ public class V3Auto extends LinearOpMode {
         feeder = new Feeder(hardwareMap);
 
         VoltageSensor battery = hardwareMap.voltageSensor.iterator().next();
-        flywheel = new FlywheelASG(hardwareMap, battery);
+        flywheel = new Flywheel(hardwareMap, battery);
 
         follower = Constants.createFollower(hardwareMap);
         follower.setStartingPose(startPose);
         follower.updatePose();
         follower.setMaxPower(1.0);
 
-        turret = new Turret();
-        turret.init(hardwareMap, "turretMotor", DcMotorSimple.Direction.REVERSE);
+        turret = new Turret(hardwareMap, RobotConfig.TURRET_MOTOR, DcMotorSimple.Direction.REVERSE);
 
         double blueFirstShotX = START_X + 35 * Math.cos(Math.toRadians(START_HEADING_DEG));
         double blueFirstShotY = START_Y + 55.0 * Math.sin(Math.toRadians(START_HEADING_DEG));

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autos/V3ClosePartner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autos/V3ClosePartner.java
@@ -1,5 +1,7 @@
 package org.firstinspires.ftc.teamcode.autos;
 
+import org.firstinspires.ftc.teamcode.RobotConfig;
+
 import com.pedropathing.follower.Follower;
 import com.pedropathing.geometry.BezierCurve;
 import com.pedropathing.geometry.BezierLine;
@@ -17,7 +19,7 @@ import com.qualcomm.robotcore.util.Range;
 import org.firstinspires.ftc.teamcode.AllianceMirror;
 import org.firstinspires.ftc.teamcode.AllianceStore;
 import org.firstinspires.ftc.teamcode.AutoStartStore;
-import org.firstinspires.ftc.teamcode.hardwareClasses.FlywheelASG;
+import org.firstinspires.ftc.teamcode.hardwareClasses.Flywheel;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Turret;
 import org.firstinspires.ftc.teamcode.pedroPathing.Constants;
 
@@ -31,7 +33,7 @@ public class V3ClosePartner extends LinearOpMode {
     private Follower follower;
     private Turret turret;
     private DcMotorEx intakeMotor;
-    private FlywheelASG flywheel;
+    private Flywheel flywheel;
 
     private boolean isRedAlliance = false;
 
@@ -172,23 +174,22 @@ public class V3ClosePartner extends LinearOpMode {
         );
         startPose = AllianceMirror.mirrorPose(blueStartPose, isRedAlliance);
 
-        intakeMotor = hardwareMap.get(DcMotorEx.class, "intake_motor");
+        intakeMotor = hardwareMap.get(DcMotorEx.class, RobotConfig.INTAKE_MOTOR);
         intakeMotor.setDirection(DcMotorSimple.Direction.REVERSE);
 
-        hoodServo = hardwareMap.get(Servo.class, "hoodServo");
-        armServo = hardwareMap.get(Servo.class, "armServo");
-        clutchServo = hardwareMap.get(Servo.class, "clutchServo");
+        hoodServo = hardwareMap.get(Servo.class, RobotConfig.HOOD_SERVO);
+        armServo = hardwareMap.get(Servo.class, RobotConfig.FEEDER_ARM_SERVO);
+        clutchServo = hardwareMap.get(Servo.class, RobotConfig.FEEDER_CLUTCH_SERVO);
 
         VoltageSensor battery = hardwareMap.voltageSensor.iterator().next();
-        flywheel = new FlywheelASG(hardwareMap, battery);
+        flywheel = new Flywheel(hardwareMap, battery);
 
         follower = Constants.createFollower(hardwareMap);
         follower.setStartingPose(startPose);
         follower.updatePose();
         follower.setMaxPower(1.0);
 
-        turret = new Turret();
-        turret.init(hardwareMap, "turretMotor", DcMotorSimple.Direction.REVERSE);
+        turret = new Turret(hardwareMap, RobotConfig.TURRET_MOTOR, DcMotorSimple.Direction.REVERSE);
 
         double blueFirstShotX = START_X + 35 * Math.cos(Math.toRadians(START_HEADING_DEG));
         double blueFirstShotY = START_Y + 55.0 * Math.sin(Math.toRadians(START_HEADING_DEG));

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autos/V3FarAuto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autos/V3FarAuto.java
@@ -1,5 +1,7 @@
 package org.firstinspires.ftc.teamcode.autos;
 
+import org.firstinspires.ftc.teamcode.RobotConfig;
+
 import com.pedropathing.follower.Follower;
 import com.pedropathing.geometry.BezierCurve;
 import com.pedropathing.geometry.BezierLine;
@@ -16,7 +18,7 @@ import org.firstinspires.ftc.teamcode.AllianceMirror;
 import org.firstinspires.ftc.teamcode.AllianceStore;
 import org.firstinspires.ftc.teamcode.AutoStartStore;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Feeder;
-import org.firstinspires.ftc.teamcode.hardwareClasses.FlywheelASG;
+import org.firstinspires.ftc.teamcode.hardwareClasses.Flywheel;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Hood;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Intake;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Turret;
@@ -31,7 +33,7 @@ public class V3FarAuto extends LinearOpMode {
     private Follower follower;
     private Turret turret;
     private Intake intake;
-    private FlywheelASG flywheel;
+    private Flywheel flywheel;
 
     private boolean isRedAlliance = false;
 
@@ -143,15 +145,14 @@ public class V3FarAuto extends LinearOpMode {
         feeder = new Feeder(hardwareMap);
 
         VoltageSensor battery = hardwareMap.voltageSensor.iterator().next();
-        flywheel = new FlywheelASG(hardwareMap, battery);
+        flywheel = new Flywheel(hardwareMap, battery);
 
         follower = Constants.createFollower(hardwareMap);
         follower.setStartingPose(startPose);
         follower.updatePose();
         follower.setMaxPower(1.0);
 
-        turret = new Turret();
-        turret.init(hardwareMap, "turretMotor", DcMotorSimple.Direction.REVERSE);
+        turret = new Turret(hardwareMap, RobotConfig.TURRET_MOTOR, DcMotorSimple.Direction.REVERSE);
 
         buildBasePaths();
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autos/V3FarAutoByYuvi.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autos/V3FarAutoByYuvi.java
@@ -2,9 +2,7 @@ package org.firstinspires.ftc.teamcode.autos;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
-import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
-import com.qualcomm.robotcore.hardware.Servo;
 import com.qualcomm.robotcore.hardware.VoltageSensor;
 import com.qualcomm.robotcore.util.ElapsedTime;
 
@@ -17,9 +15,13 @@ import com.pedropathing.paths.PathChain;
 import org.firstinspires.ftc.teamcode.AllianceMirror;
 import org.firstinspires.ftc.teamcode.AllianceStore;
 import org.firstinspires.ftc.teamcode.AutoStartStore;
-import org.firstinspires.ftc.teamcode.hardwareClasses.FlywheelASG;
+import org.firstinspires.ftc.teamcode.RobotConfig;
+import org.firstinspires.ftc.teamcode.hardwareClasses.Feeder;
+import org.firstinspires.ftc.teamcode.hardwareClasses.Flywheel;
+import org.firstinspires.ftc.teamcode.hardwareClasses.Hood;
+import org.firstinspires.ftc.teamcode.hardwareClasses.Intake;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Turret;
-import org.firstinspires.ftc.teamcode.pedroPathing.constants.Constants;
+import org.firstinspires.ftc.teamcode.pedroPathing.Constants;
 
 @Autonomous(name = "V3 Far Auto : Yuvi Edition", group = "Autonomous")
 public class V3FarAutoByYuvi extends OpMode {
@@ -27,11 +29,10 @@ public class V3FarAutoByYuvi extends OpMode {
     /* ===== Hardware Subsystems ===== */
     private Follower follower;
     private Turret turret;
-    private FlywheelASG flywheel;
-    private DcMotorEx intakeMotor;
-    private Servo hoodServo;
-    private Servo armServo;
-    private Servo clutchServo;
+    private Flywheel flywheel;
+    private Intake intake;
+    private Hood hood;
+    private Feeder feeder;
 
     /* ===== Fixed Shot Settings ===== */
     private static final double FIXED_HOOD_DEG = 53.5;
@@ -106,28 +107,24 @@ public class V3FarAutoByYuvi extends OpMode {
         follower.updatePose();
         follower.setMaxPower(1.0);
 
-        /* -- Hardware (exact names from V3FarAuto) -- */
-        intakeMotor = hardwareMap.get(DcMotorEx.class, "intake_motor");
-        intakeMotor.setDirection(DcMotorSimple.Direction.REVERSE);
-
-        hoodServo = hardwareMap.get(Servo.class, "hoodServo");
-        armServo = hardwareMap.get(Servo.class, "armServo");
-        clutchServo = hardwareMap.get(Servo.class, "clutchServo");
+        /* -- Hardware -- */
+        intake = new Intake(hardwareMap);
+        hood = new Hood(hardwareMap);
+        feeder = new Feeder(hardwareMap);
 
         VoltageSensor battery = hardwareMap.voltageSensor.iterator().next();
-        flywheel = new FlywheelASG(hardwareMap, battery);
+        flywheel = new Flywheel(hardwareMap, battery);
 
-        turret = new Turret();
-        turret.init(hardwareMap, "turretMotor", DcMotorSimple.Direction.REVERSE);
+        turret = new Turret(hardwareMap, RobotConfig.TURRET_MOTOR, DcMotorSimple.Direction.REVERSE);
 
         buildPaths();
 
         /* -- Safe defaults (exact from V3FarAuto) -- */
-        intakeMotor.setPower(0.0);
+        intake.setPower(0.0);
         flywheel.stop();
-        clutchIn();
-        armBlock();
-        setHoodAngle(FIXED_HOOD_DEG);
+        feeder.clutchIn();
+        feeder.armBlock();
+        hood.setAngle(FIXED_HOOD_DEG);
 
         telemetry.addLine("Far Auto Perfect Initialized");
         telemetry.addData("Alliance", isRedAlliance ? "RED" : "BLUE");
@@ -151,7 +148,7 @@ public class V3FarAutoByYuvi extends OpMode {
         stateTimer.reset();
         autoState = AutoState.WAIT_INITIAL_DELAY;
 
-        setHoodAngle(FIXED_HOOD_DEG);
+        hood.setAngle(FIXED_HOOD_DEG);
         flywheel.setTargetVelocity(FIXED_FLYWHEEL_RAD);
     }
 
@@ -255,7 +252,7 @@ public class V3FarAutoByYuvi extends OpMode {
         switch (autoState) {
 
             case WAIT_INITIAL_DELAY:
-                intakeMotor.setPower(0.0);
+                intake.setPower(0.0);
                 if (stateTimer.seconds() >= FIRST_SHOT_DELAY_SEC
                         && Math.abs(flywheel.getVelocityRadPerSec() - FIXED_FLYWHEEL_RAD) < FLYWHEEL_TOLERANCE) {
                     startFeedSequence();
@@ -287,9 +284,9 @@ public class V3FarAutoByYuvi extends OpMode {
 
             /* ===== DRIVE_SEG3: Deep field push — INTAKE ON to collect balls ===== */
             case DRIVE_SEG3:
-                intakeMotor.setPower(1.0); // collect balls while pushing through field
+                intake.setPower(1.0); // collect balls while pushing through field
                 if (!follower.isBusy()) {
-                    intakeMotor.setPower(0.0);
+                    intake.setPower(0.0);
                     stateTimer.reset();
                     autoState = AutoState.PAUSE_SEG3;
                 }
@@ -310,7 +307,7 @@ public class V3FarAutoByYuvi extends OpMode {
                 double dxGate = GATE_X - follower.getPose().getX();
                 double dyGate = GATE_Y - follower.getPose().getY();
                 if (Math.hypot(dxGate, dyGate) < GATE_INTAKE_THRESHOLD) {
-                    intakeMotor.setPower(1.0);
+                    intake.setPower(1.0);
                 }
                 if (!follower.isBusy()) {
                     stateTimer.reset();
@@ -320,9 +317,9 @@ public class V3FarAutoByYuvi extends OpMode {
 
             /* ===== PAUSE_SEG5: Gate wait — 2.5s collection, NO shooting ===== */
             case PAUSE_SEG5:
-                intakeMotor.setPower(1.0); // stay on to collect from gate
+                intake.setPower(1.0); // stay on to collect from gate
                 if (stateTimer.milliseconds() >= GATE_WAIT_MS) {
-                    intakeMotor.setPower(0.0);
+                    intake.setPower(0.0);
                     resetMechanisms();
                     follower.followPath(seg6, true);
                     autoState = AutoState.DRIVE_SEG6;
@@ -338,9 +335,9 @@ public class V3FarAutoByYuvi extends OpMode {
 
             /* ===== DRIVE_SEG7: Clearance curve — INTAKE ON to collect balls ===== */
             case DRIVE_SEG7:
-                intakeMotor.setPower(1.0); // collect balls on clearance sweep
+                intake.setPower(1.0); // collect balls on clearance sweep
                 if (!follower.isBusy()) {
-                    intakeMotor.setPower(0.0);
+                    intake.setPower(0.0);
                     stateTimer.reset();
                     autoState = AutoState.PAUSE_SEG7;
                 }
@@ -361,7 +358,7 @@ public class V3FarAutoByYuvi extends OpMode {
                 break;
 
             case DONE:
-                intakeMotor.setPower(0.0);
+                intake.setPower(0.0);
                 flywheel.stop();
                 turret.setAngle(0.0);
                 break;
@@ -393,8 +390,8 @@ public class V3FarAutoByYuvi extends OpMode {
     /* ===================================================================== */
 
     private void startFeedSequence() {
-        armShoot();
-        clutchIn();
+        feeder.armShoot();
+        feeder.clutchIn();
         feedTimer.reset();
         feedState = FeedState.WAIT_BEFORE_INTAKE;
     }
@@ -402,9 +399,9 @@ public class V3FarAutoByYuvi extends OpMode {
     private void updateFeedSequence() {
         if (reversingIntake) {
             if (reverseTimer.seconds() < REVERSE_TIME_SEC) {
-                intakeMotor.setPower(-1.0);
+                intake.setPower(-1.0);
             } else {
-                intakeMotor.setPower(1.0);
+                intake.setPower(1.0);
                 reversingIntake = false;
             }
         }
@@ -415,9 +412,9 @@ public class V3FarAutoByYuvi extends OpMode {
                 break;
 
             case WAIT_BEFORE_INTAKE:
-                intakeMotor.setPower(0.0);
+                intake.setPower(0.0);
                 if (feedTimer.seconds() >= FEED_START_DELAY_SEC) {
-                    intakeMotor.setPower(1.0);
+                    intake.setPower(1.0);
                     feedState = FeedState.RUN_INTAKE;
                 }
                 break;
@@ -427,8 +424,8 @@ public class V3FarAutoByYuvi extends OpMode {
                     reversingIntake = true;
                     reverseTimer.reset();
 
-                    intakeMotor.setPower(0.0);
-                    clutchOut();
+                    intake.setPower(0.0);
+                    feeder.clutchOut();
                     feedState = FeedState.DONE;
                 }
                 break;
@@ -436,32 +433,10 @@ public class V3FarAutoByYuvi extends OpMode {
     }
 
     private void resetMechanisms() {
-        clutchOut();
-        armBlock();
-        intakeMotor.setPower(0.0);
+        feeder.clutchOut();
+        feeder.armBlock();
+        intake.setPower(0.0);
         feedState = FeedState.IDLE;
-    }
-
-    /* ===================================================================== */
-    /*  SUBSYSTEM HELPERS  (exact from V3FarAuto)                            */
-    /* ===================================================================== */
-
-    private void clutchIn()  { if (clutchServo != null) clutchServo.setPosition(0.48); }
-    private void clutchOut() { if (clutchServo != null) clutchServo.setPosition(0.52); }
-    private void armBlock()  { if (armServo != null)    armServo.setPosition(0.28); }
-    private void armShoot()  { if (armServo != null)    armServo.setPosition(0.42); }
-
-    private void setHoodAngle(double angleDeg) {
-        if (hoodServo == null) return;
-        final double MIN_ANGLE = 30.0;
-        final double MAX_ANGLE = 60.0;
-        final double MIN_POS = 0.42;
-        final double MAX_POS = 0.95;
-
-        double clipped = Math.max(MIN_ANGLE, Math.min(MAX_ANGLE, angleDeg));
-        double t = (clipped - MIN_ANGLE) / (MAX_ANGLE - MIN_ANGLE);
-        double pos = MIN_POS + t * (MAX_POS - MIN_POS);
-        hoodServo.setPosition(Math.max(MIN_POS, Math.min(MAX_POS, pos)));
     }
 
     /* ===================================================================== */

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwareClasses/Feeder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwareClasses/Feeder.java
@@ -3,6 +3,8 @@ package org.firstinspires.ftc.teamcode.hardwareClasses;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.Servo;
 
+import org.firstinspires.ftc.teamcode.RobotConfig;
+
 public class Feeder {
 
     private static final double ARM_BLOCK_POS = 0.28;
@@ -14,8 +16,8 @@ public class Feeder {
     private final Servo clutchServo;
 
     public Feeder(HardwareMap hardwareMap) {
-        armServo = hardwareMap.get(Servo.class, "armServo");
-        clutchServo = hardwareMap.get(Servo.class, "clutchServo");
+        armServo = hardwareMap.get(Servo.class, RobotConfig.FEEDER_ARM_SERVO);
+        clutchServo = hardwareMap.get(Servo.class, RobotConfig.FEEDER_CLUTCH_SERVO);
     }
 
     public void armBlock() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwareClasses/Flywheel.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwareClasses/Flywheel.java
@@ -6,10 +6,12 @@ import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.VoltageSensor;
 import com.qualcomm.robotcore.util.Range;
 
-public class FlywheelASG {
+import org.firstinspires.ftc.teamcode.RobotConfig;
 
-    private final DcMotorEx flywheel1;   // no encoder (or ignored)
-    private final DcMotorEx flywheel2;   // encoder motor (USED logically by your current setup)
+public class Flywheel {
+
+    private final DcMotorEx flywheelTop;      // no encoder (or ignored)
+    private final DcMotorEx flywheelBottom;   // encoder motor (USED logically by your current setup)
     private final VoltageSensor battery;
 
     // Target velocity in rad/s
@@ -46,45 +48,45 @@ public class FlywheelASG {
 
     /**
      * Default ctor that matches your tuner naming:
-     *  - flywheel1 = "shootTop"
-     *  - flywheel2 = "shootBottom"
+     *  - flywheelTop = "shootTop"
+     *  - flywheelBottom = "shootBottom"
      *
      * Direction defaults:
      *  - shootTop REVERSE
      *  - shootBottom FORWARD
      */
-    public FlywheelASG(HardwareMap hardwareMap, VoltageSensor battery) {
-        this(hardwareMap, battery, "shootTop", "shootBottom", true, false);
+    public Flywheel(HardwareMap hardwareMap, VoltageSensor battery) {
+        this(hardwareMap, battery, RobotConfig.FLYWHEEL_TOP, RobotConfig.FLYWHEEL_BOTTOM, true, false);
     }
 
     /**
      * Fully configurable ctor.
      *
-     * @param motor1Name        hardware name for motor 1
-     * @param motor2Name        hardware name for motor 2
-     * @param motor1Reversed    direction for motor 1
-     * @param motor2Reversed    direction for motor 2
+     * @param topMotorName        hardware name for the top motor
+     * @param bottomMotorName     hardware name for the bottom motor
+     * @param topMotorReversed    direction for the top motor
+     * @param bottomMotorReversed direction for the bottom motor
      */
-    public FlywheelASG(HardwareMap hardwareMap,
-                       VoltageSensor battery,
-                       String motor1Name,
-                       String motor2Name,
-                       boolean motor1Reversed,
-                       boolean motor2Reversed) {
+    public Flywheel(HardwareMap hardwareMap,
+                    VoltageSensor battery,
+                    String topMotorName,
+                    String bottomMotorName,
+                    boolean topMotorReversed,
+                    boolean bottomMotorReversed) {
 
         this.battery = battery;
 
-        flywheel1 = hardwareMap.get(DcMotorEx.class, motor1Name);
-        flywheel2 = hardwareMap.get(DcMotorEx.class, motor2Name);
+        flywheelTop = hardwareMap.get(DcMotorEx.class, topMotorName);
+        flywheelBottom = hardwareMap.get(DcMotorEx.class, bottomMotorName);
 
-        flywheel1.setDirection(motor1Reversed ? DcMotorSimple.Direction.REVERSE : DcMotorSimple.Direction.FORWARD);
-        flywheel2.setDirection(motor2Reversed ? DcMotorSimple.Direction.REVERSE : DcMotorSimple.Direction.FORWARD);
+        flywheelTop.setDirection(topMotorReversed ? DcMotorSimple.Direction.REVERSE : DcMotorSimple.Direction.FORWARD);
+        flywheelBottom.setDirection(bottomMotorReversed ? DcMotorSimple.Direction.REVERSE : DcMotorSimple.Direction.FORWARD);
 
-        flywheel1.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.FLOAT);
-        flywheel2.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.FLOAT);
+        flywheelTop.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.FLOAT);
+        flywheelBottom.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.FLOAT);
 
-        flywheel1.setMode(DcMotorEx.RunMode.RUN_WITHOUT_ENCODER);
-        flywheel2.setMode(DcMotorEx.RunMode.RUN_WITHOUT_ENCODER);
+        flywheelTop.setMode(DcMotorEx.RunMode.RUN_WITHOUT_ENCODER);
+        flywheelBottom.setMode(DcMotorEx.RunMode.RUN_WITHOUT_ENCODER);
 
         smoothedVelocity = 0.0;
         firstVelocitySample = true;
@@ -158,8 +160,8 @@ public class FlywheelASG {
 
     /** Compute filtered velocity in rad/s. Call frequently. */
     public void updateVelocity() {
-        // Intentionally left using flywheel1 because you said the current behavior works
-        double velTicksPerSec = flywheel1.getVelocity();
+        // Intentionally left using flywheelTop because you said the current behavior works
+        double velTicksPerSec = flywheelTop.getVelocity();
         double velRadPerSec = Math.abs(velTicksPerSec) * RAD_PER_TICK;
 
         if (firstVelocitySample) {
@@ -181,9 +183,9 @@ public class FlywheelASG {
         return smoothedVelocity * 60.0 / (2.0 * Math.PI);
     }
 
-    /** Get last applied power from motor 2. */
+    /** Get last applied power from the bottom motor. */
     public double getPower() {
-        return flywheel2.getPower();
+        return flywheelBottom.getPower();
     }
 
     /**
@@ -198,8 +200,8 @@ public class FlywheelASG {
         updateVelocity();
 
         if (targetVelocity <= 0.0) {
-            flywheel1.setPower(0.0);
-            flywheel2.setPower(0.0);
+            flywheelTop.setPower(0.0);
+            flywheelBottom.setPower(0.0);
             return;
         }
 
@@ -207,15 +209,15 @@ public class FlywheelASG {
 
         // Aggressive spin-up
         if (useBangBang && smoothedVelocity < spinUpBangBangThreshold * targetVelocity) {
-            flywheel1.setPower(-1.0);
-            flywheel2.setPower(1.0);
+            flywheelTop.setPower(-1.0);
+            flywheelBottom.setPower(1.0);
             return;
         }
 
         // Aggressive spin-down
         if (useSpinDownCut && smoothedVelocity > targetVelocity + spinDownCutThresholdRad) {
-            flywheel1.setPower(0.0);
-            flywheel2.setPower(0.0);
+            flywheelTop.setPower(0.0);
+            flywheelBottom.setPower(0.0);
             return;
         }
 
@@ -226,14 +228,14 @@ public class FlywheelASG {
         double power = feedforwardPower + (kP * error);
         power = Range.clip(power, 0.0, 1.0);
 
-        flywheel1.setPower(-power);
-        flywheel2.setPower(power);
+        flywheelTop.setPower(-power);
+        flywheelBottom.setPower(power);
     }
 
     /** Immediately stop flywheel and reset filter state. */
     public void stop() {
-        flywheel1.setPower(0.0);
-        flywheel2.setPower(0.0);
+        flywheelTop.setPower(0.0);
+        flywheelBottom.setPower(0.0);
         smoothedVelocity = 0.0;
         firstVelocitySample = true;
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwareClasses/Hood.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwareClasses/Hood.java
@@ -3,6 +3,8 @@ package org.firstinspires.ftc.teamcode.hardwareClasses;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.Servo;
 
+import org.firstinspires.ftc.teamcode.RobotConfig;
+
 public class Hood {
 
     private static final double MIN_ANGLE_DEG = 30.0;
@@ -14,7 +16,7 @@ public class Hood {
     private final Servo hoodServo;
 
     public Hood(HardwareMap hardwareMap) {
-        hoodServo = hardwareMap.get(Servo.class, "hoodServo");
+        hoodServo = hardwareMap.get(Servo.class, RobotConfig.HOOD_SERVO);
     }
 
     /** Sets the hood to the given launch angle (deg), clamped to range, and returns the clamped angle. */

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwareClasses/Intake.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwareClasses/Intake.java
@@ -4,28 +4,30 @@ import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
+import org.firstinspires.ftc.teamcode.RobotConfig;
+
 public class Intake {
 
-    private final DcMotorEx motor;
+    private final DcMotorEx intakeMotor;
 
     public Intake(HardwareMap hardwareMap) {
-        motor = hardwareMap.get(DcMotorEx.class, "intake_motor");
-        motor.setDirection(DcMotorSimple.Direction.REVERSE);
+        intakeMotor = hardwareMap.get(DcMotorEx.class, RobotConfig.INTAKE_MOTOR);
+        intakeMotor.setDirection(DcMotorSimple.Direction.REVERSE);
     }
 
     public void setPower(double power) {
-        motor.setPower(power);
+        intakeMotor.setPower(power);
     }
 
     public void in() {
-        motor.setPower(1.0);
+        intakeMotor.setPower(1.0);
     }
 
     public void out() {
-        motor.setPower(-1.0);
+        intakeMotor.setPower(-1.0);
     }
 
     public void stop() {
-        motor.setPower(0.0);
+        intakeMotor.setPower(0.0);
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwareClasses/Turret.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwareClasses/Turret.java
@@ -52,7 +52,7 @@ public class Turret {
     private ControlMode controlMode = ControlMode.LEGACY_POSITION;
 
     // Initialization
-    public void init(HardwareMap hardwareMap, String motorName, DcMotorSimple.Direction direction) {
+    public Turret(HardwareMap hardwareMap, String motorName, DcMotorSimple.Direction direction) {
         turretMotor = hardwareMap.get(DcMotorEx.class, motorName);
         turretMotor.setDirection(direction);
         turretMotor.setMode(DcMotorEx.RunMode.STOP_AND_RESET_ENCODER);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/modernTests/FlywheelTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/modernTests/FlywheelTest.java
@@ -5,13 +5,13 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.VoltageSensor;
 
-import org.firstinspires.ftc.teamcode.hardwareClasses.FlywheelASG;
+import org.firstinspires.ftc.teamcode.hardwareClasses.Flywheel;
 @Disabled
 
 @TeleOp(name = "Flywheel Feedforward + kP Test", group = "Flywheel Testing")
-public class FlywheelASGTest extends LinearOpMode {
+public class FlywheelTest extends LinearOpMode {
 
-    private FlywheelASG flywheel;
+    private Flywheel flywheel;
 
     // Example target velocity (rad/s)
     private double targetVelocityRad = 250;
@@ -19,7 +19,7 @@ public class FlywheelASGTest extends LinearOpMode {
     @Override
     public void runOpMode() {
         VoltageSensor battery = hardwareMap.voltageSensor.iterator().next();
-        flywheel = new FlywheelASG(hardwareMap, battery);
+        flywheel = new Flywheel(hardwareMap, battery);
 
         // Set feedforward and kP
         flywheel.setTargetVelocity(targetVelocityRad);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Constants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/Constants.java
@@ -1,5 +1,7 @@
 package org.firstinspires.ftc.teamcode.pedroPathing;
 
+import org.firstinspires.ftc.teamcode.RobotConfig;
+
 import com.pedropathing.control.FilteredPIDFCoefficients;
 import com.pedropathing.control.PIDFCoefficients;
 import com.pedropathing.follower.Follower;
@@ -33,10 +35,10 @@ public class Constants {
     //.predictiveBrakingCoefficients(new PredictiveBrakingCoefficients(0.15, 0.146551085, 0.000622545779));
 
     public static MecanumConstants driveConstants = new MecanumConstants()
-            .leftFrontMotorName("leftFront")
-            .leftRearMotorName("leftBack")
-            .rightFrontMotorName("rightFront")
-            .rightRearMotorName("rightBack")
+            .leftFrontMotorName(RobotConfig.DRIVE_LEFT_FRONT)
+            .leftRearMotorName(RobotConfig.DRIVE_LEFT_BACK)
+            .rightFrontMotorName(RobotConfig.DRIVE_RIGHT_FRONT)
+            .rightRearMotorName(RobotConfig.DRIVE_RIGHT_BACK)
             .leftFrontMotorDirection(DcMotorSimple.Direction.FORWARD)
             .leftRearMotorDirection(DcMotorSimple.Direction.FORWARD)
             .rightFrontMotorDirection(DcMotorSimple.Direction.REVERSE)
@@ -51,7 +53,7 @@ public class Constants {
             .forwardPodY(-3)
             .strafePodX(-5.46)
             .distanceUnit(DistanceUnit.INCH)
-            .hardwareMapName("pinpoint")
+            .hardwareMapName(RobotConfig.PINPOINT)
             .yawScalar(1.0)
             .encoderResolution(
                     GoBildaPinpointDriver.GoBildaOdometryPods.goBILDA_4_BAR_POD

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teles/V3Tele.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teles/V3Tele.java
@@ -1,5 +1,7 @@
 package org.firstinspires.ftc.teamcode.teles;
 
+import org.firstinspires.ftc.teamcode.RobotConfig;
+
 import com.pedropathing.follower.Follower;
 import com.pedropathing.geometry.BezierLine;
 import com.pedropathing.geometry.Pose;
@@ -15,7 +17,7 @@ import org.firstinspires.ftc.teamcode.AllianceMirror;
 import org.firstinspires.ftc.teamcode.AllianceStore;
 import org.firstinspires.ftc.teamcode.AutoStartStore;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Feeder;
-import org.firstinspires.ftc.teamcode.hardwareClasses.FlywheelASG;
+import org.firstinspires.ftc.teamcode.hardwareClasses.Flywheel;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Hood;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Intake;
 import org.firstinspires.ftc.teamcode.hardwareClasses.Turret;
@@ -31,7 +33,7 @@ public class V3Tele extends LinearOpMode {
     private Turret turret;
 
     private Intake intake;
-    private FlywheelASG flywheel;
+    private Flywheel flywheel;
 
     private boolean isRedAlliance = false;
 
@@ -184,7 +186,7 @@ public class V3Tele extends LinearOpMode {
         feeder = new Feeder(hardwareMap);
 
         VoltageSensor battery = hardwareMap.voltageSensor.iterator().next();
-        flywheel = new FlywheelASG(hardwareMap, battery);
+        flywheel = new Flywheel(hardwareMap, battery);
 
         isRedAlliance = AllianceStore.isRed(hardwareMap.appContext);
         boolean isCloseAuto = AutoStartStore.isClose(hardwareMap.appContext);
@@ -202,8 +204,7 @@ public class V3Tele extends LinearOpMode {
         follower.setMaxPower(1);
         follower.startTeleOpDrive();
 
-        turret = new Turret();
-        turret.init(hardwareMap, "turretMotor", DcMotorSimple.Direction.REVERSE);
+        turret = new Turret(hardwareMap, RobotConfig.TURRET_MOTOR, DcMotorSimple.Direction.REVERSE);
 
         feeder.clutchOut();
         feeder.armBlock();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuners/FeedForwardTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuners/FeedForwardTuner.java
@@ -1,5 +1,7 @@
 package org.firstinspires.ftc.teamcode.tuners;
 
+import org.firstinspires.ftc.teamcode.RobotConfig;
+
 import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
@@ -22,13 +24,13 @@ public class FeedForwardTuner extends LinearOpMode {
 
     @Override
     public void runOpMode() {
-        DcMotorEx flywheel = hardwareMap.get(DcMotorEx.class, "shootTop");
-        flywheel.setDirection(DcMotorSimple.Direction.REVERSE);
-        DcMotorEx flywheel2 = hardwareMap.get(DcMotorEx.class, "shootBottom");
+        DcMotorEx flywheelTop = hardwareMap.get(DcMotorEx.class, RobotConfig.FLYWHEEL_TOP);
+        flywheelTop.setDirection(DcMotorSimple.Direction.REVERSE);
+        DcMotorEx flywheelBottom = hardwareMap.get(DcMotorEx.class, RobotConfig.FLYWHEEL_BOTTOM);
         VoltageSensor battery = hardwareMap.voltageSensor.iterator().next();
 
-        flywheel.setMode(DcMotorEx.RunMode.RUN_WITHOUT_ENCODER);
-        flywheel.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.FLOAT);
+        flywheelTop.setMode(DcMotorEx.RunMode.RUN_WITHOUT_ENCODER);
+        flywheelTop.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.FLOAT);
 
         telemetry.addLine("Feedforward Tuner Ready");
         telemetry.addLine("Ensure flywheel can spin safely");
@@ -43,11 +45,11 @@ public class FeedForwardTuner extends LinearOpMode {
 
         // Sweep through power stepse
         for (double power : POWER_STEPS) {
-            flywheel.setPower(-power);
-            flywheel2.setPower(power);
+            flywheelTop.setPower(-power);
+            flywheelBottom.setPower(power);
             sleep((long)(WAIT_TIME * 1000));
 
-            double velTicks = flywheel.getVelocity();
+            double velTicks = flywheelTop.getVelocity();
             double velRad = -velTicks * 2 * Math.PI / 28.0;
             double velRPM = -velRad * 60 / (2 * Math.PI);
 
@@ -62,8 +64,8 @@ public class FeedForwardTuner extends LinearOpMode {
             telemetry.update();
         }
 
-        flywheel.setPower(0);
-        flywheel2.setPower(0);
+        flywheelTop.setPower(0);
+        flywheelBottom.setPower(0);
         // Linear regression: power = kV*ω + kS
         double meanVel = velocitiesRad.stream().mapToDouble(Double::doubleValue).average().orElse(0);
         double meanPower = powers.stream().mapToDouble(Double::doubleValue).average().orElse(0);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuners/FlywheelKpTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuners/FlywheelKpTuner.java
@@ -5,7 +5,7 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.VoltageSensor;
 
-import org.firstinspires.ftc.teamcode.hardwareClasses.FlywheelASG;
+import org.firstinspires.ftc.teamcode.hardwareClasses.Flywheel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +14,7 @@ import java.util.List;
 @TeleOp(name = "Flywheel kP Tuner", group = "Flywheel Tuning")
 public class FlywheelKpTuner extends LinearOpMode {
 
-    private FlywheelASG flywheel;
+    private Flywheel flywheel;
 
     // Example target velocity (rad/s)
     private static final double TARGET_VELOCITY_RAD = 250;
@@ -26,7 +26,7 @@ public class FlywheelKpTuner extends LinearOpMode {
     @Override
     public void runOpMode() {
         VoltageSensor battery = hardwareMap.voltageSensor.iterator().next();
-        flywheel = new FlywheelASG(hardwareMap, battery);
+        flywheel = new Flywheel(hardwareMap, battery);
 
         // Replace with feedforward values from previous tuner
         double kV = 0.0016;


### PR DESCRIPTION
## Summary
- Fixes 3 compile errors in `V3FarAutoByYuvi.java`: `FlywheelASG` (renamed to `Flywheel`), wrong `pedroPathing.Constants` import path, and a nonexistent `Turret.init()`/no-arg constructor.
- Renames `FlywheelASG` -> `Flywheel` (and the matching test `FlywheelASGTest` -> `FlywheelTest`).
- Adds `RobotConfig` as a central registry of device-name string constants.
- Switches `Hood`, `Feeder`, `Intake`, and `Turret` to constructor injection (take `HardwareMap`/deps in the constructor, reference `RobotConfig` constants) and updates all callers (`V3Auto`, `V3ClosePartner`, `V3FarAuto`, `V3FarAutoByYuvi`, `V3Tele`, tuners) accordingly.
- `V3FarAutoByYuvi` now uses `Feeder`/`Hood`/`Intake` instead of raw `Servo`/`DcMotorEx` field access, removing duplicated magic-number helper methods.

## Test plan
- [x] `./gradlew :TeamCode:compileDebugJavaWithJavac` succeeds with no errors (only pre-existing deprecation warnings).
- [ ] Build/deploy via Android Studio and run "V3 Far Auto : Yuvi Edition" on the practice field to verify the path segments (especially the 6-point Bezier curves on seg1/seg7) and gate-collection timing behave as intended.